### PR TITLE
accessibility - background colors change for better contrast-ratio

### DIFF
--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1046,14 +1046,14 @@ section{
     }
 
     .mada{
-     box-shadow: 0px 3px 10px #E5313180;
-        background-color: #DE3B3B;
+      /* box-shadow: 0px 3px 10px #E5313180; */
+      background-color: #BF2C3B;
     }
 
 
     .health{
-        background-color: #2FBAD8;
-        box-shadow: 0px 3px 10px #2FBAD880;
+       /* box-shadow: 0px 3px 10px #2FBAD880; */
+       background-color: #0E61ff;
     }
 
 /*========== nav-bar end ==========*/


### PR DESCRIPTION
### Regarding issue #51 :
It Seems that a few things were fixed since then.
I improved a bit the link buttons background colors to pass the WCAG 2.0 test on contrast ratio.
Now the lighthouse test for accessibility is passing with a score of 100!

<img width="839" alt="Screen Shot 2020-03-19 at 18 24 19" src="https://user-images.githubusercontent.com/47426218/77090869-713c0000-6a10-11ea-8374-e864a1a78c0a.png">


