### PR TITLE
Adding Thai language i18n translation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,7 @@
     <script defer src="languages/en.js"></script>
     <script defer src="languages/ar.js"></script>
     <script defer src="languages/ru.js"></script>
+    <script defer src="languages/th.js"></script>
     <script defer src="../js/utils.js"></script>
     <script defer src="js/app.js"></script>
 

--- a/public/languages/th.js
+++ b/public/languages/th.js
@@ -1,0 +1,59 @@
+;(function () {
+
+  // Establish the root object, `window` in the browser, or `global` on the server.
+  const root = this;
+
+  // Thai translation th-TH
+  const th = {
+    direction: 'ltr',
+    title: 'คอรอนาแผนที่ในประเทศอิสราเอล', // Israel Corona Map
+    patientNumber: 'คนไข้มายเลข', // Patient number
+    patientNumberShort: 'คนไข้', // Patient
+    visitingTimes: 'ชั่วโมงที่เขาอยู่ที่นั่น', // Visiting times
+    visitingTime: '', // Visit time
+    publishedDate: 'ปรากฏ', // Publication Date
+    timeLeftForStayingInSolitary: 'เหลือเวลาสำหรับกักกันเสร็จ', // Time left for quarantine
+    expire14DaysAfterExposure: '14 วันที่ผ่านมากักบริเวณไม่ได้', // 14 days have passed - no need for quarantine
+    linkToTheMinistryOfHealthPublication:'ปรากฏอิสราเอลกระทรวงสาธารณสุขโดย', // Ministry Of Health official publication
+    days: 'วัน', // days
+    hours:'ชั่วโมง', // hours
+    minutes:'นาที', // minutes
+    secondes: 'วินาที', // seconds
+    betweenTheHours: '',
+    departure: 'จะออก', // Departure
+    arrival: 'จะลงจอด', // Arrival
+    flightSearchPlaceholder: 'ใช้หาเที่ยวบินหรือที่ตั้งรือวันที่รือคนไข้เบอร์', // Search by flight, location, date, patient number
+    'last-updated-text': 'เช็คด้วย', // Last Updated In:
+    'magen-david-adom': 'อิสราเอลฉุกเฉินเบอร์โทรศัพท์ 101', // Magen David Adom: 101
+    'health-ministry': 'อิสราเอลกระทรวงสาธารณสุขเบอร์โทรศัพท์ *5400', // Ministry of Health: *5400
+    'search-for-flights': 'ใช้หาเที่ยวบิน', // Search for flights
+    'embed-code': 'Embeded code generator',
+    'about': 'เกี่ยวกับเว็บไซต์', // About
+    'contact-use': 'ติดต่อ', // Contact us
+    'select-language': 'ใช้เปลี่ยนภาษา', // Change language
+    'state-of-patients-israel': 'Patient statistics',
+    'number-of-sick-people': 'คนไข้เป็นไม่ค่อยสบาย', // Sick Patients
+    'number-of-recovered-people': 'หาย', // Recovered
+    'number-of-deaths': 'มรณะ', // Deaths
+    'number-of-people-in-quarantine': 'คนอิสราเอลอยู่ที่ในเป็นกักบริเวณ', // People In Quarantine
+    'sick-update-title': 'Statistics เป็นคนไข้', // Patient Statistics
+  };
+
+  // Thai language does not refer to plural
+  th.visitingTime = th.visitingTimes;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = th;
+  } else {
+    try {
+      if( ( 'langs' in root ) === false )
+        throw 'langs object does not found.';
+
+      root['langs']['th'] = th;
+    }
+    catch(err) {
+      console.error(err);
+    }
+  }
+})();
+


### PR DESCRIPTION
Hi there!
There are many Thai people in Israel, most of them don't read English or Hebrew well. I added a translation in Thai to allow them use the map as well.
I can speak and write in Thai, but it is important to know that in Thai there are many ways you cannot be expressed as in English or Hebrew, so if you will use a dictionary, you can find sentences that "unequal" to the (e.g) English twin sentence translation.
Hope you can confirm,
Thanks!